### PR TITLE
Lesson 1 5

### DIFF
--- a/app/dashboard/customers/page.tsx
+++ b/app/dashboard/customers/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>Customers Page</p>;
+}

--- a/app/dashboard/invoices/page.tsx
+++ b/app/dashboard/invoices/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>Invoices Page</p>;
+}

--- a/app/dashboard/layout.tsx
+++ b/app/dashboard/layout.tsx
@@ -1,0 +1,14 @@
+import SideNav from '@/app/ui/dashboard/sidenav';
+ 
+// This is the layout for all /dashboard routes
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="flex h-screen flex-col md:flex-row md:overflow-hidden">
+      <div className="w-full flex-none md:w-64">
+        <SideNav />
+      </div>
+      <div className="flex-grow p-6 md:overflow-y-auto md:p-12">{children}</div>
+    </div>
+  );
+}

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1,0 +1,6 @@
+// This is the main page for the /dashboard route
+// page.tsx files in Next.js are the default pages for their respective directories
+
+export default function Page() {
+  return <p>Dashboard Page</p>;
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,3 +1,8 @@
+import '@/app/ui/global.css';
+import { inter } from '@/app/ui/fonts';
+
+// This is the root layout that wraps the entire application
+
 export default function RootLayout({
   children,
 }: {
@@ -5,7 +10,7 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en">
-      <body>{children}</body>
+      <body className={`${inter.className} antialiased`}>{children}</body>
     </html>
   );
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,16 +1,21 @@
 import AcmeLogo from '@/app/ui/acme-logo';
 import { ArrowRightIcon } from '@heroicons/react/24/outline';
 import Link from 'next/link';
+import Image from 'next/image';
+import styles from '@/app/ui/home.module.css';
+import { lusitana } from '@/app/ui/fonts';
 
 export default function Page() {
   return (
     <main className="flex min-h-screen flex-col p-6">
       <div className="flex h-20 shrink-0 items-end rounded-lg bg-blue-500 p-4 md:h-52">
-        {/* <AcmeLogo /> */}
+        <AcmeLogo />
       </div>
       <div className="mt-4 flex grow flex-col gap-4 md:flex-row">
         <div className="flex flex-col justify-center gap-6 rounded-lg bg-gray-50 px-6 py-10 md:w-2/5 md:px-20">
-          <p className={`text-xl text-gray-800 md:text-3xl md:leading-normal`}>
+          <div className={styles.shape} /> 
+          {/* added shape and specific font style */}
+          <p className={`${lusitana.className} text-xl text-gray-800 md:text-3xl md:leading-normal`}> 
             <strong>Welcome to Acme.</strong> This is the example for the{' '}
             <a href="https://nextjs.org/learn/" className="text-blue-500">
               Next.js Learn Course
@@ -26,6 +31,20 @@ export default function Page() {
         </div>
         <div className="flex items-center justify-center p-6 md:w-3/5 md:px-28 md:py-12">
           {/* Add Hero Images Here */}
+          <Image
+          src="/hero-desktop.png"
+          width={1000}
+          height={760}
+          className="hidden md:block"
+          alt="Screenshots of the dashboard project showing desktop version"
+          />
+          <Image
+          src="/hero-mobile.png"
+          width={500}
+          height={620}
+          className="block md:hidden"
+          alt="Screenshots of the dashboard project showing mobile version"
+          />
         </div>
       </div>
     </main>

--- a/app/ui/dashboard/nav-links.tsx
+++ b/app/ui/dashboard/nav-links.tsx
@@ -1,8 +1,13 @@
+'use client';
+
 import {
   UserGroupIcon,
   HomeIcon,
   DocumentDuplicateIcon,
 } from '@heroicons/react/24/outline';
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import clsx from 'clsx';
 
 // Map of links to display in the side navigation.
 // Depending on the size of the application, this would be stored in a database.
@@ -17,19 +22,26 @@ const links = [
 ];
 
 export default function NavLinks() {
+  const pathname = usePathname(); // Hook to get the current pathname
+
   return (
     <>
       {links.map((link) => {
         const LinkIcon = link.icon;
         return (
-          <a
+          <Link
             key={link.name}
             href={link.href}
-            className="flex h-[48px] grow items-center justify-center gap-2 rounded-md bg-gray-50 p-3 text-sm font-medium hover:bg-sky-100 hover:text-blue-600 md:flex-none md:justify-start md:p-2 md:px-3"
-          >
+            className={clsx( // Using clsx to conditionally apply classes
+              'flex h-[48px] grow items-center justify-center gap-2 rounded-md bg-gray-50 p-3 text-sm font-medium hover:bg-sky-100 hover:text-blue-600 md:flex-none md:justify-start md:p-2 md:px-3',
+              {
+                'bg-sky-100 text-blue-600': pathname === link.href, // Active link styling  
+              },
+            )}
+            >
             <LinkIcon className="w-6" />
             <p className="hidden md:block">{link.name}</p>
-          </a>
+          </Link>
         );
       })}
     </>

--- a/app/ui/fonts.ts
+++ b/app/ui/fonts.ts
@@ -1,0 +1,6 @@
+// file to manage fonts used in the application
+
+import { Inter, Lusitana  } from 'next/font/google';
+
+export const inter = Inter({ subsets: ['latin'] });
+export const lusitana = Lusitana({ subsets: ['latin'], weight: ['400', '700'] });

--- a/app/ui/home.module.css
+++ b/app/ui/home.module.css
@@ -1,0 +1,7 @@
+.shape {
+  height: 0;
+  width: 0;
+  border-bottom: 30px solid black;
+  border-left: 20px solid transparent;
+  border-right: 20px solid transparent;
+}


### PR DESCRIPTION
This pull request introduces the initial layout and navigation for the dashboard section of the application, sets up global and dashboard-specific styles, and enhances the home page with improved visuals and font management. The changes establish the foundational structure for both the dashboard and landing pages, including navigation, layout, and responsive design elements.

**Dashboard Structure and Navigation:**

* Created a new dashboard layout in `app/dashboard/layout.tsx` that includes a sidebar navigation (`SideNav`) and responsive content area.
* Added individual page components for `/dashboard`, `/dashboard/customers`, and `/dashboard/invoices`, each displaying placeholder content. [[1]](diffhunk://#diff-e16c1c1133d5d72341ada507f3e06fa37dd79de574403f158159ff934f9b5013R1-R6) [[2]](diffhunk://#diff-e88fcf14e17acceb1264ee6570dc9dffbd85d23d18ef7a6d217909decd02f2e5R1-R3) [[3]](diffhunk://#diff-7a396b3ea61186c1b9d7e90ad29f275b4eddcf019160b56992bf2ac3c4db0476R1-R3)
* Improved the sidebar navigation in `app/ui/dashboard/nav-links.tsx` to use Next.js `Link`, highlight the active route, and apply conditional styling with `clsx`. [[1]](diffhunk://#diff-8835d61db67c9042ee4c6db4a90566c52bf0b9c88b09e2575ebb3b93a1d9afbfR1-R10) [[2]](diffhunk://#diff-8835d61db67c9042ee4c6db4a90566c52bf0b9c88b09e2575ebb3b93a1d9afbfR25-R44)

**Styling and Fonts:**

* Introduced a global font management file (`app/ui/fonts.ts`) to centralize font imports and usage, including `Inter` and `Lusitana`.
* Updated the root layout in `app/layout.tsx` to apply the `Inter` font and antialiasing to the entire application.

**Home Page Enhancements:**

* Enhanced the landing page (`app/page.tsx`) with a new shape visual (using a new CSS class in `app/ui/home.module.css`), custom font (`Lusitana`), and responsive hero images for desktop and mobile. [[1]](diffhunk://#diff-6efdf509a785a0658b2e31a8c33d298de14321d9672179370e99cc76241c1eb0R4-R18) [[2]](diffhunk://#diff-6efdf509a785a0658b2e31a8c33d298de14321d9672179370e99cc76241c1eb0R34-R47) [[3]](diffhunk://#diff-dde4a4fd63dc8f76df468028a9eb844d4c2eda0110b065bd5dff9a0852f3c571R1-R7)